### PR TITLE
Example: add html tag + fix url

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Include it on web pages with `iframe`, such as :
 Params are passed to the app using query variables :
 
 Example :
-```
+```html
 <iframe
   style="border: none; margin: 0 0; padding: 0 0; width: 80%; height: 400px"
-  src="https://jlm2017.github.io/closest-groups-map/?zipcode=[code-postal]&event_type=melenchon&circonscriptions=1">
+  src="https://jlm2017.github.io/map/?zipcode=[code-postal]&event_type=melenchon&circonscriptions=1">
 </iframe>
 ```
 


### PR DESCRIPTION
In the README.md, the example for the params contains the line
`src="https://jlm2017.github.io/closest-groups-map/?zipcode=[code-postal]&event_type=melenchon&circonscriptions=1">`
However, the parameters are ignored with this address. This should be
`src="https://jlm2017.github.io/map/?zipcode=[code-postal]&event_type=melenchon&circonscriptions=1">`